### PR TITLE
Fix Posts always showing "Continue Reading"

### DIFF
--- a/templates/partials/blog_item.html.twig
+++ b/templates/partials/blog_item.html.twig
@@ -126,8 +126,6 @@
       <p>
         {% if truncate and page.summary != page.content %}
         <a href="{{ page.url }}" class="read-more">Continue Reading</a>
-        {% elseif truncate %}
-        <a href="{{ page.url }}" class="read-more">Continue Reading</a>
         {% endif %}
       </p>
       {% else %}


### PR DESCRIPTION
I removed the elseif statement that always displayed "Continue Reading" regardless of if the summary matched the content.